### PR TITLE
Update the Cargo config file to point to GH email id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "quade"
 version = "0.0.1"
-authors = ["Sayan Chowdhury <sayan.chowdhury2012@gmail.com>"]
-edition = "2018"
+authors = ["Sayan Chowdhury <namoskar@yudocaa.in>"]
+edition = "2019"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This commit is a step to remove the references to the s.c<year> email id